### PR TITLE
Changed test for presense of Chris Lea PPA to work on different versions of Ubuntu.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,7 @@ package "python-software-properties"
 
 execute "setup ppa apt repository" do
   command "add-apt-repository ppa:chris-lea/node.js && apt-get update"
-  not_if  "test -f /etc/apt/sources.list.d/chris-lea-node.js-lucid.list"
+  not_if  "ls /etc/apt/sources.list.d/chris-lea*"
 end
 
 package "nodejs"


### PR DESCRIPTION
On Ubuntu 12.04 source file located in `/etc/apt/sources.list.d/chris-lea-node_js-precise.list`. I've changed `not_if` block to test presence of chris-lea\* in sources directory.
