### PR TITLE
Added the node.js-legacy repository

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,6 +14,16 @@ when "ubuntu"
     keyserver "keyserver.ubuntu.com"
     action :add
   end
+  
+  
+  apt_repository "chris-lea-node.js-legacy" do
+    uri "http://ppa.launchpad.net/chris-lea/node.js-legacy/ubuntu"
+    distribution node["lsb"]["codename"]
+    components ["main"]
+    key "C7917B12"
+    keyserver "keyserver.ubuntu.com"
+    action :add
+  end
 
 when "debian"
 


### PR DESCRIPTION
Older versions have now been moved to the node.js-legacy repository. If you're version locked to a generation behind the latest, then your apt packages won't break
